### PR TITLE
Fix Peachpie build using local sources

### DIFF
--- a/frameworks/PHP/peachpie/NuGet.config
+++ b/frameworks/PHP/peachpie/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local" value="peachpie/.nugs" />
+  </packageSources>
+</configuration>

--- a/frameworks/PHP/peachpie/Server/Server.csproj
+++ b/frameworks/PHP/peachpie/Server/Server.csproj
@@ -11,10 +11,10 @@
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.0-rc1-final" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.0-rc1-final" />
     <PackageReference Include="Microsoft.AspNetCore.Buffering" Version="0.2.2" />
+    <PackageReference Include="Peachpie.NETCore.Web" Version="0.9.1-dev" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\peachpie\src\Peachpie.NETCore.Web\Peachpie.NETCore.Web.csproj" />
     <ProjectReference Include="..\Website\Website.msbuildproj" />
   </ItemGroup>
 

--- a/frameworks/PHP/peachpie/Website/NuGet.config
+++ b/frameworks/PHP/peachpie/Website/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="local" value="../packages" />
-  </packageSources>
-</configuration>

--- a/frameworks/PHP/peachpie/Website/Website.msbuildproj
+++ b/frameworks/PHP/peachpie/Website/Website.msbuildproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <DotNetCliToolReference Include="Peachpie.Compiler.Tools" Version="0.9.1-dev" />
-    <ProjectReference Include="..\peachpie\src\Peachpie.NET.Sdk\Peachpie.NET.Sdk.csproj" />
+    <PackageReference Include="Peachpie.NET.Sdk" Version="0.9.1-dev" PrivateAssets="Build" />
   </ItemGroup>
 
 </Project>

--- a/frameworks/PHP/peachpie/peachpie.dockerfile
+++ b/frameworks/PHP/peachpie/peachpie.dockerfile
@@ -1,10 +1,7 @@
 FROM microsoft/dotnet:2.1-sdk-stretch AS build
 WORKDIR /app
 COPY . .
-RUN dotnet build -c Release peachpie/src/Peachpie.Compiler.Tools/Peachpie.Compiler.Tools.csproj
-RUN dotnet build -c Release peachpie/src/Peachpie.CodeAnalysis/Peachpie.CodeAnalysis.csproj
-RUN dotnet pack peachpie/src/Peachpie.Compiler.Tools -c Release -o ../../../packages
-RUN dotnet pack peachpie/src/Peachpie.CodeAnalysis -c Release -o ../../../packages
+RUN dotnet build -c Release peachpie/Peachpie.sln
 RUN dotnet publish -c Release -o ../out Server
 
 FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime


### PR DESCRIPTION
The Peachpie NuGet packages are automatically put in the ```.nugs``` folder when the solution is build, hence no need for ```dotnet pack``` and the ```packages``` folder. ```Peachpie.NET.Sdk``` mustn't be referenced as a project, because that way ```Website``` doesn't include the Peachpie MSBuild ```.targets``` file.